### PR TITLE
bugfix for multiple @param tags

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -44,28 +44,24 @@ function _compact(tags){
   //  {"type":"","string":"The two defined `addClass` will be taken into account in the popover"},
   //  {"type":"type","types":["String"]}]
 
-  var index = {};
   var compacted = [];
 
   tags.forEach(function(tag, i){
     if(!tag.type){
       if(i === 0){return;}
       // append to previous
-      compacted[compacted.length-1].string += " " + tag.string;
+      var prevTag = compacted[compacted.length-1];
+      if (prevTag.description) {
+        prevTag.description += " " + tag.string;
+      } else {
+        prevTag.string += " " + tag.string;
+      }
       return;
     }
-
-    if(!index.hasOwnProperty(tag.type)){
-      index[tag.type] = compacted.length;
-      compacted.push(tag);
-      return;
-    }
-
-    // Merge with
-    compacted[index[tag.type]].string += " " + tag.string;
+    
+    compacted.push(tag);
   });
 
-  index = null;
   return compacted;
 }
 

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -35,6 +35,16 @@ exports['._compact'] = function(t){
     {"type": "","string": "b"},
     {"type": "","string": "c"},
     {"type": "","string": "d"},
+    {"type": "param","name":"cl","types":["String"],"description": "a Css class"},
+    {
+      "type": "param",
+      "name": "options",
+      "types": ["Object"],
+      "description": "d"
+    },
+    {"type": "","string": "c"},
+    {"type": "","string": "b"},
+    {"type": "","string": "a"},
     {
       "type": "type",
       "types": ["String"]
@@ -52,8 +62,9 @@ exports['._compact'] = function(t){
   };
 
   var compacted = parser._compact(symbol.tags);
-  t.equal(compacted.length, 2);
+  t.equal(compacted.length, 4);
   t.equal(compacted[0].string, "a b c d");
+  t.equal(compacted[2].description, "d c b a");
 
   t.done();
 };


### PR DESCRIPTION
hi, i changed the _compact function in parser.js to keep multiple occurrences of the same tag type in separate objects. Also additional lines of text are appended to tag.description instead of tag.string when defined.
