### PR TITLE
made CDN links protocol relative

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -9,9 +9,9 @@ html
   head
     meta(name='viewport', content='width=device-width', charset='utf-8')
     title= title
-    link(rel="stylesheet", href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css")
-    link(rel="stylesheet", href="http://twitter.github.com/bootstrap/assets/css/bootstrap-responsive.css")
-    link(rel="stylesheet", href="http://twitter.github.com/bootstrap/assets/css/docs.css")
+    link(rel="stylesheet", href="//twitter.github.com/bootstrap/assets/css/bootstrap.css")
+    link(rel="stylesheet", href="//twitter.github.com/bootstrap/assets/css/bootstrap-responsive.css")
+    link(rel="stylesheet", href="//twitter.github.com/bootstrap/assets/css/docs.css")
     style
       body > .navbar .brand {
         float:left;
@@ -33,10 +33,10 @@ html
       code[class*="language-"],pre[class*="language-"]{color:black;text-shadow:0 1px white;font-family:Consolas,Monaco,'Andale Mono',monospace;direction:ltr;text-align:left;white-space:pre;word-spacing:normal;-moz-tab-size:4;-o-tab-size:4;tab-size:4;-webkit-hyphens:none;-moz-hyphens:none;-ms-hyphens:none;hyphens:none}pre[class*="language-"]{padding:1em;margin:.5em 0;overflow:auto}:not(pre)>code[class*="language-"],pre[class*="language-"]{background:#f5f2f0}:not(pre)>code[class*="language-"]{padding:.1em;border-radius:.3em}.token.comment,.token.prolog,.token.doctype,.token.cdata{color:slategray}.token.punctuation{color:#999}.namespace{opacity:.7}.token.property,.token.tag,.token.boolean,.token.number{color:#905}.token.selector,.token.attr-name,.token.string{color:#690}.token.operator,.token.entity,.token.url,.language-css .token.string,.style .token.string{color:#a67f59;background:hsla(0,0%,100%,.5)}.token.atrule,.token.attr-value,.token.keyword{color:#07a}.token.regex,.token.important{color:#e90}.token.important{font-weight:bold}.token.entity{cursor:help}
       div.description {margin: 14px 0; padding-top: 14px; border-bottom:1px solid #eee; }
       .tags {}
-      .ctx-type { 
+      .ctx-type {
         display:inline-block;
         margin-right:0.5em;
-        //- float:right; margin-top:8px 
+        //- float:right; margin-top:8px
       }
 
       footer iframe{vertical-align:middle;}
@@ -48,7 +48,7 @@ html
           a.brand Doxx
           div.nav-collapse.collapse
             ul.nav.pull-right.sponsored
-              
+
 
     header.jumbotron.subhead#overview
       div.container
@@ -88,7 +88,7 @@ html
                     if symbol.ctx.string
                       span= symbol.ctx.string
                     if symbol.return
-                      |  -> 
+                      |  ->
                       span= symbol.return
 
               if symbol.hasParams
@@ -111,33 +111,33 @@ html
               pre
                 code.language-javascript
                   = symbol.code
-    
+
     footer.footer
       div.container
-        p Documentation generated with 
-          a(href="https://github.com/FGRibreau/doxx") Doxx 
-          | created by 
+        p Documentation generated with
+          a(href="https://github.com/FGRibreau/doxx") Doxx
+          | created by
           a.twitter-follow-button(href='https://twitter.com/FGRibreau',data-show-count='false') Francois-Guillaume Ribreau
-        p Doxx is sponsored by 
-          a.bringr(href='http://bringr.net/?btt', title="Outil d'analyse des réseaux sociaux") Bringr 
-          | and 
+        p Doxx is sponsored by
+          a.bringr(href='//bringr.net/?btt', title="Outil d'analyse des réseaux sociaux") Bringr
+          | and
           a.redsmin(href='https://redsmin.com/?btt', title="Full Redis GUI") Redsmin
         p Theme borrowed from Twitter Bootstrap
-    
-    script(src="http://platform.twitter.com/widgets.js")
-    script(src="http://ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js")
-    script(src="http://leaverou.github.com/prefixfree/prefixfree.js")
-    script(src="http://twitter.github.com/bootstrap/assets/js/bootstrap-transition.js")
-    script(src="http://twitter.github.com/bootstrap/assets/js/bootstrap-scrollspy.js")
-    script(src="http://twitter.github.com/bootstrap/assets/js/bootstrap-dropdown.js")
-    script(src="http://twitter.github.com/bootstrap/assets/js/bootstrap-collapse.js")
-    script(src="http://twitter.github.com/bootstrap/assets/js/bootstrap-affix.js")
+
+    script(src="//platform.twitter.com/widgets.js")
+    script(src="//ajax.googleapis.com/ajax/libs/jquery/1.8/jquery.min.js")
+    script(src="//leaverou.github.com/prefixfree/prefixfree.js")
+    script(src="//twitter.github.com/bootstrap/assets/js/bootstrap-transition.js")
+    script(src="//twitter.github.com/bootstrap/assets/js/bootstrap-scrollspy.js")
+    script(src="//twitter.github.com/bootstrap/assets/js/bootstrap-dropdown.js")
+    script(src="//twitter.github.com/bootstrap/assets/js/bootstrap-collapse.js")
+    script(src="//twitter.github.com/bootstrap/assets/js/bootstrap-affix.js")
 
     script
       /**
        * Prism: Lightweight, robust, elegant syntax highlighting
-       * MIT license http://www.opensource.org/licenses/mit-license.php/
-       * @author Lea Verou http://lea.verou.me
+       * MIT license //www.opensource.org/licenses/mit-license.php/
+       * @author Lea Verou //lea.verou.me
        */(function(){var e=/\blang(?:uage)?-(?!\*)(\w+)\b/i,t=self.Prism={util:{type:function(e){return Object.prototype.toString.call(e).match(/\[object (\w+)\]/)[1]},clone:function(e){var n=t.util.type(e);switch(n){case"Object":var r={};for(var i in e)e.hasOwnProperty(i)&&(r[i]=t.util.clone(e[i]));return r;case"Array":return e.slice()}return e}},languages:{extend:function(e,n){var r=t.util.clone(t.languages[e]);for(var i in n)r[i]=n[i];return r},insertBefore:function(e,n,r,i){i=i||t.languages;var s=i[e],o={};for(var u in s)if(s.hasOwnProperty(u)){if(u==n)for(var a in r)r.hasOwnProperty(a)&&(o[a]=r[a]);o[u]=s[u]}return i[e]=o},DFS:function(e,n){for(var r in e){n.call(e,r,e[r]);t.util.type(e)==="Object"&&t.languages.DFS(e[r],n)}}},highlightAll:function(e,n){var r=document.querySelectorAll('code[class*="language-"], [class*="language-"] code, code[class*="lang-"], [class*="lang-"] code');for(var i=0,s;s=r[i++];)t.highlightElement(s,e===!0,n)},highlightElement:function(r,i,s){var o,u,a=r;while(a&&!e.test(a.className))a=a.parentNode;if(a){o=(a.className.match(e)||[,""])[1];u=t.languages[o]}if(!u)return;r.className=r.className.replace(e,"").replace(/\s+/g," ")+" language-"+o;a=r.parentNode;/pre/i.test(a.nodeName)&&(a.className=a.className.replace(e,"").replace(/\s+/g," ")+" language-"+o);var f=r.textContent;if(!f)return;f=f.replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/\u00a0/g," ");var l={element:r,language:o,grammar:u,code:f};t.hooks.run("before-highlight",l);if(i&&self.Worker){var c=new Worker(t.filename);c.onmessage=function(e){l.highlightedCode=n.stringify(JSON.parse(e.data));l.element.innerHTML=l.highlightedCode;s&&s.call(l.element);t.hooks.run("after-highlight",l)};c.postMessage(JSON.stringify({language:l.language,code:l.code}))}else{l.highlightedCode=t.highlight(l.code,l.grammar);l.element.innerHTML=l.highlightedCode;s&&s.call(r);t.hooks.run("after-highlight",l)}},highlight:function(e,r){return n.stringify(t.tokenize(e,r))},tokenize:function(e,n){var r=t.Token,i=[e],s=n.rest;if(s){for(var o in s)n[o]=s[o];delete n.rest}e:for(var o in n){if(!n.hasOwnProperty(o)||!n[o])continue;var u=n[o],a=u.inside,f=!!u.lookbehind||0;u=u.pattern||u;for(var l=0;l<i.length;l++){var c=i[l];if(i.length>e.length)break e;if(c instanceof r)continue;u.lastIndex=0;var h=u.exec(c);if(h){f&&(f=h[1].length);var p=h.index-1+f,h=h[0].slice(f),d=h.length,v=p+d,m=c.slice(0,p+1),g=c.slice(v+1),y=[l,1];m&&y.push(m);var b=new r(o,a?t.tokenize(h,a):h);y.push(b);g&&y.push(g);Array.prototype.splice.apply(i,y)}}}return i},hooks:{all:{},add:function(e,n){var r=t.hooks.all;r[e]=r[e]||[];r[e].push(n)},run:function(e,n){var r=t.hooks.all[e];if(!r||!r.length)return;for(var i=0,s;s=r[i++];)s(n)}}},n=t.Token=function(e,t){this.type=e;this.content=t};n.stringify=function(e){if(typeof e=="string")return e;if(Object.prototype.toString.call(e)=="[object Array]"){for(var r=0;r<e.length;r++)e[r]=n.stringify(e[r]);return e.join("")}var i={type:e.type,content:n.stringify(e.content),tag:"span",classes:["token",e.type],attributes:{}};i.type=="comment"&&(i.attributes.spellcheck="true");t.hooks.run("wrap",i);var s="";for(var o in i.attributes)s+=o+'="'+(i.attributes[o]||"")+'"';return"<"+i.tag+' class="'+i.classes.join(" ")+'" '+s+">"+i.content+"</"+i.tag+">"};if(!self.document){self.addEventListener("message",function(e){var n=JSON.parse(e.data),r=n.language,i=n.code;self.postMessage(JSON.stringify(t.tokenize(i,t.languages[r])));self.close()},!1);return}var r=document.getElementsByTagName("script");r=r[r.length-1];if(r){t.filename=r.src;document.addEventListener&&!r.hasAttribute("data-manual")&&document.addEventListener("DOMContentLoaded",t.highlightAll)}})();;
       Prism.languages.markup={comment:/&lt;!--[\w\W]*?--(&gt;|&gt;)/g,prolog:/&lt;\?.+?\?&gt;/,doctype:/&lt;!DOCTYPE.+?&gt;/,cdata:/&lt;!\[CDATA\[[\w\W]+?]]&gt;/i,tag:{pattern:/&lt;\/?[\w:-]+\s*(?:\s+[\w:-]+(?:=(?:("|')(\\?[\w\W])*?\1|\w+))?\s*)*\/?&gt;/gi,inside:{tag:{pattern:/^&lt;\/?[\w:-]+/i,inside:{punctuation:/^&lt;\/?/,namespace:/^[\w-]+?:/}},"attr-value":{pattern:/=(?:('|")[\w\W]*?(\1)|[^\s>]+)/gi,inside:{punctuation:/=|&gt;|"/g}},punctuation:/\/?&gt;/g,"attr-name":{pattern:/[\w:-]+/g,inside:{namespace:/^[\w-]+?:/}}}},entity:/&amp;#?[\da-z]{1,8};/gi};Prism.hooks.add("wrap",function(e){e.type==="entity"&&(e.attributes.title=e.content.replace(/&amp;/,"&"))});;
       Prism.languages.css={comment:/\/\*[\w\W]*?\*\//g,atrule:/@[\w-]+?(\s+[^;{]+)?(?=\s*{|\s*;)/gi,url:/url\((["']?).*?\1\)/gi,selector:/[^\{\}\s][^\{\}]*(?=\s*\{)/g,property:/(\b|\B)[a-z-]+(?=\s*:)/ig,string:/("|')(\\?.)*?\1/g,important:/\B!important\b/gi,ignore:/&(lt|gt|amp);/gi,punctuation:/[\{\};:]/g};Prism.languages.markup&&Prism.languages.insertBefore("markup","tag",{style:{pattern:/(&lt;|<)style[\w\W]*?(>|&gt;)[\w\W]*?(&lt;|<)\/style(>|&gt;)/ig,inside:{tag:{pattern:/(&lt;|<)style[\w\W]*?(>|&gt;)|(&lt;|<)\/style(>|&gt;)/ig,inside:Prism.languages.markup.tag.inside},rest:Prism.languages.css}}});;


### PR DESCRIPTION
Hi

When serving up compiled docs up from a server they only work in FF/Chrome if the server is http.  If the server is https then because the CDN assets are being loaded from http then the browser blocks it.  Using protocol relative URLs fixes the issue since all those CDNs support https too :)

Cheers
