### PR TITLE
Fix --ignore option not being passed to collectFiles correctly

### DIFF
--- a/bin/doxx
+++ b/bin/doxx
@@ -60,7 +60,7 @@ var target = path.resolve(process.cwd(), program.target) || process.cwd() + '/do
 ignore     = ignore.trim().replace(' ','').split(',');
 
 // Find, cleanup and validate all potential files
-var files  = dir.collectFiles(source, ignore);
+var files  = dir.collectFiles(source, {ignore:ignore});
 
 
 mkdirp.sync(target);


### PR DESCRIPTION
The bin/doxx script call `dir.collectFiles(source, ignore)`, but the function is expecting the second parameter to be an options hash

```
function collectFiles(source, options) {
    var dirtyFiles = findit.findSync(source), // tee hee!
        ignore     = options.ignore || [],
```
