### PR TITLE
Added an option to include jsFiddle embed links within code comments

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -34,6 +34,7 @@ var hasParams      = has('param');
 var isReturn       = has('return');
 var hasDescription = has('description');
 var hasType        = has('type');
+var hasJSFiddle    = has('jsFiddle');
 
 /**
  * Compact multi-line expression
@@ -77,6 +78,7 @@ function _mapSymbol(symbol){
   var types       = symbol.tags.filter(hasType);
   var description = symbol.tags.filter(hasDescription);
   var returns     = symbol.tags.filter(isReturn);
+  var jsfiddle    = symbol.tags.filter(hasJSFiddle);
 
   if(symbol.tags.length > 0 && symbol.tags.filter(hasParams).length > 0){
     symbol.hasParams = true;
@@ -103,6 +105,10 @@ function _mapSymbol(symbol){
     symbol.description.extra = "<p>"+description[0].string+"</p>";
   }
 
+  if(jsfiddle.length === 1){
+    symbol.jsfiddle = jsfiddle[0].string;
+  }
+    
   return symbol;
 }
 /**

--- a/views/template.jade
+++ b/views/template.jade
@@ -119,6 +119,10 @@ html
               pre
                 code.language-javascript
                   = symbol.code
+            if symbol.jsfiddle
+              h5 jsFiddle
+              p
+                iframe(width="100%", height="300", src=symbol.jsfiddle , allowfullscreen="allowfullscreen", frameborder="0")
 
     footer.footer
       div.container


### PR DESCRIPTION
The following changes allows insertion of a jsFiddle URL that will be embedded as an iframe on the HTML output.

For example:
/**
- @jsFiddle http://jsfiddle.net/monteslu/vcKdF/embedded/
  */
