### PR TITLE
Dangling text for symbol.name caused jade 1.1.5 to create a html element...

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -74,10 +74,12 @@ html
                 li
                   if name === currentName
                     a(href='#'+symbol.name)
-                      mixin iForSymbolType(symbol) #{symbol.name}
+                      mixin iForSymbolType(symbol)
+                      span #{symbol.name}
                   else
                     a(href=symbol.targetFile+'#'+symbol.name)
-                      mixin iForSymbolType(symbol) #{symbol.name}
+                      mixin iForSymbolType(symbol)
+                      span #{symbol.name}
 
         .span9
           if locals.readme


### PR DESCRIPTION
... instead of a string. Create proper html span element and insert symbol.name there
![missing_text](https://cloud.githubusercontent.com/assets/4658815/2677814/048224e2-c158-11e3-8679-559ce7f98b1d.png)
