### PR TITLE
Fixes style distruptancies for sidenav on long paths and lists

### DIFF
--- a/views/template.jade
+++ b/views/template.jade
@@ -21,6 +21,11 @@ html
         font-weight:normal;
       }
 
+      .bs-docs-sidenav.affix {
+        box-shadow: 0 0 20px 1px rgba(0, 0, 0, 0.5);
+        z-index: 10;
+      }
+
       .bs-docs-sidenav i{
         width: 8px;
         height: 8px;
@@ -28,6 +33,10 @@ html
         margin: 0px;
         display: inline-block;
         margin-right:0.5em;
+      }
+
+      .bs-docs-sidenav > li > a {
+          word-wrap: break-word;
       }
 
       .bs-docs-sidenav > li:first-child > a {
@@ -128,13 +137,13 @@ html
 
     footer.footer
       div.container
-        p Documentation generated with 
-          a(href="https://github.com/FGRibreau/doxx") Doxx 
-          | created by 
+        p Documentation generated with
+          a(href="https://github.com/FGRibreau/doxx") Doxx
+          | created by
           a.twitter-follow-button(href='https://twitter.com/FGRibreau',data-show-count='false') Francois-Guillaume Ribreau
-        p Doxx is sponsored by 
-          a.bringr(href='http://bringr.net/?btt', title="Outil d'analyse des réseaux sociaux") Bringr 
-          | and 
+        p Doxx is sponsored by
+          a.bringr(href='http://bringr.net/?btt', title="Outil d'analyse des réseaux sociaux") Bringr
+          | and
           a.redsmin(href='https://redsmin.com/?btt', title="Full Redis GUI") Redsmin
         p Theme borrowed from Twitter Bootstrap
 


### PR DESCRIPTION
This patches fixes some minor, yet annoying glitches when viewing long documentation pages:
- in the sidenav: for long paths the text would not break and the path was not readable
- in the sidenav: for long lists the affix sidenav was not distinguishable from the base sidenav and created visual clutter
  ![sidenav_affix](https://cloud.githubusercontent.com/assets/4658815/2688167/75792bac-c287-11e3-9a39-4443248dfe62.png)
  ![sidenav_long-paths](https://cloud.githubusercontent.com/assets/4658815/2688168/757ab3d2-c287-11e3-8a04-e1f560143c2f.png)
