### PR TITLE
Exposing as a node module

### DIFF
--- a/bin/doxx
+++ b/bin/doxx
@@ -2,25 +2,16 @@
 "use strict";
 
 var program = require('commander'),
-    fs      = require('fs'),
-    path    = require('path'),
-    mkdirp  = require('mkdirp'),
-    _       = require('lodash'),
-    marked  = require('marked'),
-
-    dir     = require('../lib/dir'),
-    parse   = require('../lib/parser'),
-    compile = require('../lib/compile'),
-    symbols = require('../lib/symbols'),
-
-    version = require('../package').version;
+    version = require('../package').version,
+    doxx = require('../lib/index'),
+    defaults = require('../lib/defaults');
 
 /**
  * Options & Defaults
  */
-var ignoredDirs = 'test,public,static,views,templates',
-    pkg,
-    target_extension = 'html';
+var ignoredDirs = defaults.ignoredDirs,
+pkg = defaults.pkg,
+target_extension = defaults.tartget_extension;
 
 program
   .version(version)
@@ -48,130 +39,4 @@ program.on('--help', showHelp);
 // parse argv
 program.parse(process.argv);
 
-if(program.target_extension){
-  target_extension = program.target_extension;
-}
-
-if(program.template){
-  compile.tpl = fs.readFileSync(program.template).toString();
-  compile.tplFileName = program.template;
-}
-
-if (!program.source) {
-  console.error("  Error you must define a source\n");
-  return showHelp();
-}
-
-var target = path.resolve(process.cwd(), program.target) || process.cwd() + '/docs',
-    source = path.resolve(process.cwd(), program.source),
-    ignore = program.ignore || ignoredDirs;
-
-// Cleanup and turn into an array the ignoredDirs
-ignore     = ignore.trim().replace(' ','').split(',');
-
-// Find, cleanup and validate all potential files
-var files  = dir.collectFiles(source, {ignore:ignore});
-
-
-mkdirp.sync(target);
-
-// Parse each file
-files = files.map(function(file) {
-  var dox = parse(path.join(source, file), {});
-  var targetName = file+'.'+target_extension;
-  return {
-    name:       file,
-    targetName: targetName,
-    dox:        dox,
-    symbols:    symbols(dox, targetName)
-  };
-});
-
-// Compute all symboles
-var allSymbols = files.reduce(function(m, a){
-  m = m.concat(a.symbols || []);
-  return m;
-}, []);
-
-// Get package.json 
-try{
-  pkg = require(process.cwd() + '/package')
-} catch (err) {
-}
-
-var readme = pkg && pkg.readme 
-  , readMeFile = path.resolve(process.cwd(), program.readme || (pkg && pkg.readmeFileName) || 'README.md')
-
-if(!readme && fs.existsSync(readMeFile)){
-  readme = fs.readFileSync(readMeFile).toString()
-} else {
-  console.warn(new Error('No README.md file found at ' + readMeFile))
-}
-
-readme = readme || (pkg && pkg.description)
-
-// Enable line-breaks ala github markdown
-marked.setOptions({
-  breaks: true,
-  smartLists: true
-})
-
-// Get readme data
-files.unshift({
-  name:"Main",
-  targetName: "index.html",
-  readme: marked(readme),
-  dox:[],
-  symbols:[]
-});
-
-// Make sure the folder structure in target mirrors source
-var folders = [];
-
-files.forEach(function(file){
-  var folder = file.targetName.substr(0, file.targetName.lastIndexOf(path.sep));
-
-  if ((folder !== '') && (folders.indexOf(folder) === -1)) {
-    folders.push(folder);
-    mkdirp.sync(target + '/' + folder);
-  }
-});
-
-
-// Render and write each file
-files.forEach(function(file){
-
-  // Set each files relName in relation to where this file is in the directory tree
-  files.forEach(function(f){
-
-    // Count how deep the current file is in relation to base
-    var count = file.name.split(path.sep);
-    count = count === null ? 0 : count.length - 1;
-
-    // relName is equal to targetName at the base dir
-    f.relName = f.targetName;
-
-    // For each directory in depth of current file add a ../ to the relative filename of this link
-    while (count > 0) {
-      f.relName = '../' + f.relName;
-      count--;
-    }
-
-  });
-
-  var title = program.title;
-
-  if (!title) {
-    title = pkg && pkg.name || 'Title Not Set'
-  }
-
-  var options = _.extend({}, file, {
-    title:        title,
-    allSymbols:   allSymbols,
-    files:        files,
-    currentName:  file.name
-  });
-  
-  var compiled = compile(options);
-  fs.writeFileSync(path.join(target, file.targetName), compiled);
-});
+doxx(program);

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -1,0 +1,8 @@
+/**
+ * Options & Default configuration options.
+ */
+module.exports = {
+		ignoredDirs: 'test,public,static,views,templates',
+		pkg: undefined,
+		target_extension: 'html'
+}

--- a/lib/doxx.js
+++ b/lib/doxx.js
@@ -1,0 +1,154 @@
+"use strict";
+
+var 
+path = require('path'),
+dir = require('../lib/dir'),
+fs      = require('fs'),
+mkdirp  = require('mkdirp'),
+_       = require('lodash'),
+marked  = require('marked'),
+parse   = require('./parser'),
+compile = require('./compile'),
+symbols = require('./symbols'),
+defaults = require('./defaults');
+
+/**
+ * Options & Defaults
+ */
+var ignoredDirs = defaults.ignoredDirs,
+pkg = defaults.pkg,
+target_extension = defaults.target_extension;
+
+module.exports = function(options) {
+
+	if(options.target_extension){
+		target_extension = options.target_extension;
+	}
+
+	if(options.template){
+		compile.tpl = fs.readFileSync(options.template).toString();
+		compile.tplFileName = options.template;
+	}
+
+	if (!options.source) {
+		console.error("  Error you must define a source\n");
+		return showHelp();
+	}
+	
+
+	var target = path.resolve(process.cwd(), options.target) || process.cwd() + '/docs',
+	source = path.resolve(process.cwd(), options.source),
+	ignore = options.ignore || ignoredDirs;
+
+	//Cleanup and turn into an array the ignoredDirs
+	ignore     = ignore.trim().replace(' ','').split(',');
+
+	//Find, cleanup and validate all potential files
+	var files  = dir.collectFiles(source, {ignore:ignore});
+
+
+	mkdirp.sync(target);
+
+	//Parse each file
+	files = files.map(function(file) {
+		var dox = parse(path.join(source, file), {});
+		var targetName = file+'.'+target_extension;
+		return {
+			name:       file,
+			targetName: targetName,
+			dox:        dox,
+			symbols:    symbols(dox, targetName)
+		};
+	});
+
+	//Compute all symboles
+	var allSymbols = files.reduce(function(m, a){
+		m = m.concat(a.symbols || []);
+		return m;
+	}, []);
+
+	//Get package.json 
+	try{
+		pkg = require(process.cwd() + '/package')
+	} catch (err) {
+	}
+
+	var readme = pkg && pkg.readme 
+	, readMeFile = path.resolve(process.cwd(), options.readme || (pkg && pkg.readmeFileName) || 'README.md')
+
+	if(!readme && fs.existsSync(readMeFile)){
+		readme = fs.readFileSync(readMeFile).toString()
+	} else {
+		console.warn(new Error('No README.md file found at ' + readMeFile))
+	}
+
+	readme = readme || (pkg && pkg.description)
+
+	//Enable line-breaks ala github markdown
+	marked.setOptions({
+		breaks: true,
+		smartLists: true
+	})
+
+	//Get readme data
+	files.unshift({
+		name:"Main",
+		targetName: "index.html",
+		readme: marked(readme),
+		dox:[],
+		symbols:[]
+	});
+
+	//Make sure the folder structure in target mirrors source
+	var folders = [];
+
+	files.forEach(function(file){
+		var folder = file.targetName.substr(0, file.targetName.lastIndexOf(path.sep));
+
+		if ((folder !== '') && (folders.indexOf(folder) === -1)) {
+			folders.push(folder);
+			mkdirp.sync(target + '/' + folder);
+		}
+	});
+
+
+	//Render and write each file
+	files.forEach(function(file){
+
+		// Set each files relName in relation to where this file is in the directory tree
+		files.forEach(function(f){
+
+			// Count how deep the current file is in relation to base
+			var count = file.name.split(path.sep);
+			count = count === null ? 0 : count.length - 1;
+
+			// relName is equal to targetName at the base dir
+			f.relName = f.targetName;
+
+			// For each directory in depth of current file add a ../ to the relative filename of this link
+			while (count > 0) {
+				f.relName = '../' + f.relName;
+				count--;
+			}
+
+		});
+
+		var title = options.title;
+
+		if (!title) {
+			title = pkg && pkg.name || 'Title Not Set'
+		}
+
+		var compileOptions = _.extend({}, file, {
+			title:        title,
+			allSymbols:   allSymbols,
+			files:        files,
+			currentName:  file.name
+		});
+
+		var compiled = compile(compileOptions);
+		fs.writeFileSync(path.join(target, file.targetName), compiled);
+	});
+
+
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "type": "MIT",
     "url": "https://github.com/FGRibreau/doxx/blob/master/LICENSE-MIT"
   }],
-  "main": "lib/doxx",
+  "main": "lib/doxx.js",
   "bin": {
     "doxx": "./bin/doxx"
   },


### PR DESCRIPTION
Per issue #37

Adding lib/doxx.js as node "main" file in package.json.  Moving main application logic from bin/doxx to
lib/doxx.js and bin/doxx calls lib/doxx.js.  Adding lib/defaults.js to
specify default program options (shared by lib/doxx.js and bin/doxx).
