### PR TITLE
Adding the ability to send in pre-compiled dox source

### DIFF
--- a/lib/doxx.js
+++ b/lib/doxx.js
@@ -32,34 +32,48 @@ module.exports = function(options) {
 
 	if (!options.source) {
 		console.error("  Error you must define a source\n");
-		return showHelp();
+		return;
 	}
-	
+
 
 	var target = path.resolve(process.cwd(), options.target) || process.cwd() + '/docs',
-	source = path.resolve(process.cwd(), options.source),
 	ignore = options.ignore || ignoredDirs;
 
 	//Cleanup and turn into an array the ignoredDirs
-	ignore     = ignore.trim().replace(' ','').split(',');
-
-	//Find, cleanup and validate all potential files
-	var files  = dir.collectFiles(source, {ignore:ignore});
-
+	ignore = ignore.trim().replace(' ','').split(',');
 
 	mkdirp.sync(target);
+	
+	var source;
 
-	//Parse each file
-	files = files.map(function(file) {
-		var dox = parse(path.join(source, file), {});
-		var targetName = file+'.'+target_extension;
-		return {
-			name:       file,
-			targetName: targetName,
-			dox:        dox,
-			symbols:    symbols(dox, targetName)
-		};
-	});
+	if (options.source instanceof Array) {
+		source = options.source;
+		//Handle already compiled input
+		var files = source.map(function(doc) {
+			var targetName = doc.name+'.'+target_extension;
+			if (!doc.targetName) doc.targetName = targetName;
+			doc.symbols = symbols(doc.dox, doc.targetName);
+			return doc;
+		});
+	} else {
+		//Compile files
+		//Find, cleanup and validate all potential files
+		source = path.resolve(process.cwd(), options.source);
+		var files  = dir.collectFiles(source, {ignore:ignore});
+
+		//Parse each file
+		files = files.map(function(file) {
+			var dox = parse(path.join(source, file), {});
+			var targetName = file+'.'+target_extension;
+			return {
+				name:       file,
+				targetName: targetName,
+				dox:        dox,
+				symbols:    symbols(dox, targetName)
+			};
+		});
+
+	}
 
 	//Compute all symboles
 	var allSymbols = files.reduce(function(m, a){
@@ -111,7 +125,6 @@ module.exports = function(options) {
 		}
 	});
 
-
 	//Render and write each file
 	files.forEach(function(file){
 
@@ -149,6 +162,5 @@ module.exports = function(options) {
 		var compiled = compile(compileOptions);
 		fs.writeFileSync(path.join(target, file.targetName), compiled);
 	});
-
 
 }


### PR DESCRIPTION
Instead of `options.source` being a directory, it can now either be a directory (string) or it can be an array of objects in the following format:

``` javascript
{
  name: '...', // required, name of the resource being documented
  dox: [...], // required, array of dox comments for the resource.  This is a substitute for the output of the parser
  targetName: '...' // optional, name of the output file.  Defaults to [name].[target_extension], where target_extension is set from the options to doxx
}

Essentially, this allows the user to specify if they want to use the default dox parser engine in doxx, or if they want to compile the dox themselves and use the doxx engine for compilation of the output files.
```
