### PR TITLE
Search source folder in the project root directory, not in the system…

### DIFF
--- a/lib/mr-doc.js
+++ b/lib/mr-doc.js
@@ -100,18 +100,18 @@ class Doc extends Compiler {
         }
         // Make sure the sub dirs that are not blacklisted exist.
         const {
-          source, output, blacklist
+          output, blacklist
         } = this.options,
-          outputDir = output.substring(process.cwd().length);
+          sourcePath = Path.normalize(process.cwd() + '/' + this.options.source);
 
-        File.walk(this.options.source)
+        File.walk(sourcePath)
           .on('readable', function() {
             let item;
             while ((item = this.read())) {
               if (item.stats.isDirectory()) {
                 const path = Path.normalize(item
                   .path
-                  .replace(Path.join(source), outputDir));
+                  .replace(sourcePath, output));
                 if (blacklist.some(folder => path.indexOf(folder) < 0))
                   File.ensureDirSync(path);
               }


### PR DESCRIPTION
Search source folder in the project root directory, not in the system root directory.

We have an issue when the whole path from system root contains source folder name, e.g. 
```javascript
grunt.config('mrdoc', {
        lib: {
            src: 'lib',
            target: '<%= reports %>',

        }
    });
```
`D:\project\libs\image-service\lib\ximm.js`
Then docs created in `D:\project` not in `D:\project\libs\image-service\lib\`

Thank you!